### PR TITLE
Add support for the item's course

### DIFF
--- a/pytraccar/api.py
+++ b/pytraccar/api.py
@@ -66,6 +66,7 @@ class API(object):
                         devinfo[unique_id]['latitude'] = pos.get('latitude')
                         devinfo[unique_id]['longitude'] = pos.get('longitude')
                         devinfo[unique_id]['altitude'] = pos.get('altitude')
+                        devinfo[unique_id]['course'] = pos.get('course')
                         devinfo[unique_id]['speed'] = pos.get('speed')
                         devattr = pos.get('attributes', {})
                         battery_level = devattr.get('batteryLevel')


### PR DESCRIPTION
The `/position` API call also returns the item's course.  This PR adds the course to the returned device's info