### PR TITLE
Add get_events() and fix id in get_device_info()

### DIFF
--- a/pytraccar/api.py
+++ b/pytraccar/api.py
@@ -8,8 +8,7 @@ import asyncio
 import logging
 import socket
 
-from datetime import timedelta
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import aiohttp
 import async_timeout

--- a/pytraccar/api.py
+++ b/pytraccar/api.py
@@ -139,16 +139,13 @@ class API(object):
 
     async def get_events(self, deviceIds=[], groupIds=[],
                          fromTime=None, toTime=None, eventTypes=['allEvents']):
-        if not deviceIds and not groupIds:
-            _LOGGER.error('At least one deviceId or one groupId must be passed')
-            return
+        """Get the local installed version."""
         if toTime is None:
             toTime = datetime.utcnow()
         if fromTime is None:
             """Default interval 30sec"""
-            fromTime=toTime - timedelta(seconds=30)
-        """Get the local installed version."""
-        base_url = self._api + '/reports/events'     
+            fromTime = toTime - timedelta(seconds=30)
+        base_url = self._api + '/reports/events'
         get_params = []
         get_params.extend([('deviceId', value) for value in deviceIds])
         get_params.extend([('groupId', value) for value in groupIds])

--- a/pytraccar/api.py
+++ b/pytraccar/api.py
@@ -8,11 +8,11 @@ import asyncio
 import logging
 import socket
 
-import aiohttp
-import async_timeout
-
 from datetime import timedelta
 from datetime import datetime
+
+import aiohttp
+import async_timeout
 
 _LOGGER = logging.getLogger(__name__)
 HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
@@ -138,13 +138,16 @@ class API(object):
             _LOGGER.error('Error fetching data from Traccar, %s', error)
 
     async def get_events(self, device_ids, group_ids=None,
-                         from_time=None, to_time=None, event_types=['allEvents']):
+                         from_time=None, to_time=None,
+                         event_types=None):
         """Get the local installed version."""
         default_interval = 30
         if to_time is None:
             to_time = datetime.utcnow()
         if from_time is None:
             from_time = to_time - timedelta(seconds=default_interval)
+        if event_types is None:
+            event_types = ['allEvents']
         base_url = self._api + '/reports/events'
         get_params = []
         get_params.extend([('deviceId', value) for value in device_ids])


### PR DESCRIPTION
Hi @ludeeus ,

I would like to submit one new functionality and one "fix":

1) get_events() implements API https://www.traccar.org/api-reference/#path--reports-events
2) fix for device's traccar id that previously was always overwritten by the name (I chose a simple 'traccar_id' key)

That particular id will be useful when used in combination with get_events()