### PR TITLE
Fix: return correct attribute value

### DIFF
--- a/pytraccar/api.py
+++ b/pytraccar/api.py
@@ -97,11 +97,11 @@ class API(object):  # pylint: disable=too-many-instance-attributes
 
                         for attribute in ATTRIBUTES["position"]:
                             key = ATTRIBUTES["position"][attribute]
-                            devinfo[uid][attribute] = key
+                            devinfo[uid][attribute] = pos[key]
 
                         for attribute in ATTRIBUTES["device"]:
                             key = ATTRIBUTES["device"][attribute]
-                            devinfo[uid][attribute] = key
+                            devinfo[uid][attribute] = dev[key]
 
                         devinfo[uid]["battery"] = nested.get("batteryLevel")
                         devinfo[uid]["motion"] = nested.get("motion")


### PR DESCRIPTION
* Now returns the name of the attribute instead of value in device and position attributes.
```
Device info: {'124567890': {'address': 'address', 'latitude': 'latitude', 'longitude': 'longitude', 'accuracy': 'accuracy', 'altitude': 'altitude', 'course': 'course', 'speed': 'speed', 'traccar_id': 'id', 'device_id': 'name', 'updated': 'lastUpdate', 'category': 'category', 'battery': 85.0, 'motion': False, 'geofence': None}
```
* Modified to return the value of attribute