### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     tests_require=["pytest", "aiohttp", "pytest-asyncio", "aresponses"],
     long_description_content_type="text/markdown",
     url="https://github.com/ludeeus/pytraccar",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests",)),
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     tests_require=["pytest", "aiohttp", "pytest-asyncio", "aresponses"],
     long_description_content_type="text/markdown",
     url="https://github.com/ludeeus/pytraccar",
-    packages=setuptools.find_packages(exclude=("tests",)),
+    packages=setuptools.find_packages(exclude=["tests.*", "tests"]),
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Installing tests is generally not desirable in the first place, but particularly not in the global top level `tests` package.