### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/pytraccar/api.py
+++ b/pytraccar/api.py
@@ -41,7 +41,7 @@ class API(object):  # pylint: disable=too-many-instance-attributes
         data = None
         url = "{}/{}".format(self._api, endpoint)
         try:
-            async with async_timeout.timeout(8, loop=self._loop):
+            async with async_timeout.timeout(8):
                 response = await self._session.get(
                     url, auth=self._auth, headers=HEADERS, params=params
                 )


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed