### PR TITLE
Fix installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Installation
 
 ```bash
-python3 -m install pytraccar
+$ pip install pytraccar
 ```
 
 Look at the file `example.py` for a usage example.


### PR DESCRIPTION
Previously, the installation instruction read:

    python3 -m install pytraccar

That makes little sense. I suspect it had been typed out carelessly from muscle-memory. This commit changes the instruction to what actually works:

    pip install pytraccar